### PR TITLE
Feature/0.5 dep warn

### DIFF
--- a/src/composite-systems.jl
+++ b/src/composite-systems.jl
@@ -260,26 +260,6 @@ function expand_indices(actingOn::Vector, dims::Vector)
     actingOnDim = prod(dims[actingOn])
     sm = (actingOnDim, actingOnDim)
     lenm = actingOnDim^2;
-    M = expand(reshape(1:lenm, sm), actingOn, dims)
+    M = expand(reshape([1:lenm;], sm), actingOn, dims)
     return IndexSet[find(M .== x) for x in 1:lenm]
-end
-
-function expm_eigen(A::Matrix, t)
-    #Calculates expm(t*A) via eigenvalue decomposition and assuming Hermitian matrix
-    F = eigfact(Hermitian(A))
-
-    # V * diagm(exp(t*D)) * V'
-    return scale(F[:vectors], exp(t*F[:values])) * F[:vectors]'
-end
-
-function unitary_propagator(sys::CompositeQSystem, timeStep::Float64, startTime::Float64, endTime::Float64)
-
-    #Preallocate Hamiltonian memory
-    Ham = zeros(Complex128, (dim(sys), dim(sys)))
-    Uprop = @parallel (*) for time = startTime:timeStep:endTime
-        #a *= b expands to a = a*b
-        hamiltonian_add!(Ham, sys, time)
-        expm_eigen(Ham, 1im*timeStep)
-    end
-    return Uprop'
 end

--- a/src/evolution.jl
+++ b/src/evolution.jl
@@ -4,9 +4,6 @@ export ## Methods
        liouvillian_propagator,
        liouvillian_evolution
 
-# const liblapack = Base.liblapack_name
-# import Base.LinAlg: BlasChar, BlasInt, blas_int
-
 using ExpmV
 
 function expm_eigen(A::Matrix, t)
@@ -15,118 +12,6 @@ function expm_eigen(A::Matrix, t)
 
     return F[:vectors] * Diagonal(exp(t*F[:values])) * F[:vectors]'
 end
-#=
-function allocate_workspace(dim::Int)
-    #Allocate workspace for Hermitian eigensolver for matrices of dimension dim
-
-    #Create a random hermitian matrix
-    A = rand((dim,dim)) + 1im*rand((dim,dim))
-    H = A + A'
-
-
-    #Make the initial call as a workspace query with lwork=-1
-        # subroutine zheevr   (
-        #       character   JOBZ,
-        #       character   RANGE,
-        #       character   UPLO,
-        #       integer     N,
-        #       complex*16, dimension( lda, * )     A,
-        #       integer     LDA,
-        #       double precision    VL,
-        #       double precision    VU,
-        #       integer     IL,
-        #       integer     IU,
-        #       double precision    ABSTOL,
-        #       integer     M,
-        #       double precision, dimension( * )    W,
-        #       complex*16, dimension( ldz, * )     Z,
-        #       integer     LDZ,
-        #       integer, dimension( * )     ISUPPZ,
-        #       complex*16, dimension( * )  WORK,
-        #       integer     LWORK,
-        #       double precision, dimension( * )    RWORK,
-        #       integer     LRWORK,
-        #       integer, dimension( * )     IWORK,
-        #       integer     LIWORK,
-        #       integer     INFO )
-
-    jobz = 'V' # compute both eigenvalues and eigenvectors
-    range = 'A' # all eigenvalues will be found
-    uplo = 'U' # upper triangle storage (but we have full matrices anyways)
-    n = blas_int(dim)
-    vl = 0.0 #lower limit of eigenvalues: range = 'A'
-    vu = 0.0 #upper limit of eigenvalues: range = 'A'
-    il = blas_int(0) #lower number of eigenvalue to find: range = 'A'
-    iu = blas_int(0) #upper number of eigenvalue to find: range = 'A'
-    abstol = -1.0 # precision: negative for full precision
-    m = Array(BlasInt, 1) #number of non-zero eigenvalues found
-    w = zeros(Float64, dim) #array for eigenvalues
-    z = zeros(Complex128, (dim,dim)) #array for eigenvectors
-    ldz = blas_int(dim) # number of rows in Z
-
-    #Make initial allocation of empty work arrays
-    isuppz = Array(BlasInt, 2*dim)
-    work  = Array(Complex128, 1)
-    lwork = blas_int(-1)
-    rwork = Array(Float64, 1)
-    lrwork = blas_int(-1)
-    iwork = Array(BlasInt, 1)
-    liwork = blas_int(-1)
-    info  = Array(BlasInt, 1)
-
-    ccall((:zheevr_64_, liblapack), Void,
-                    (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt},
-                     Ptr{Complex128}, Ptr{BlasInt}, Ptr{Float64}, Ptr{Float64},
-                     Ptr{BlasInt}, Ptr{BlasInt}, Ptr{Complex128}, Ptr{BlasInt},
-                     Ptr{Float64}, Ptr{Complex128}, Ptr{BlasInt}, Ptr{BlasInt},
-                     Ptr{Complex128}, Ptr{BlasInt}, Ptr{Float64}, Ptr{BlasInt},
-                     Ptr{BlasInt},Ptr{BlasInt}, Ptr{BlasInt}),
-                    &jobz, &range, &uplo, &n,
-                    A, &n, &vl, &vu,
-                    &il, &iu, &abstol, m,
-                    w, z, &ldz, isuppz,
-                    work, &lwork, rwork, &lrwork,
-                    iwork, &liwork, info)
-
-    #Update the work arrays
-    lwork = blas_int(real(work[1]))
-    work = Array(Complex128, lwork)
-    lrwork = blas_int(rwork[1])
-    rwork = Array(Float64, lrwork)
-    liwork = iwork[1]
-    iwork = Array(BlasInt, liwork)
-
-
-    #Return all the allocated memory
-    return (jobz, range, uplo, n, vl, vu, il, iu, abstol, m, w, z, ldz, isuppz, work, lwork, rwork, lrwork, iwork, liwork, info)
-
-end
-
-function expm_eigen!(A::Matrix, t, jobz, range, uplo, n, vl, vu, il, iu, abstol, m, w, z, ldz, isuppz, work, lwork, rwork, lrwork, iwork, liwork, info)
-    #Matrix exponential exp(t*A) for Hermitian matrix
-    #Works via Hermitian eigensolver
-    #This version requires preallocated workspace memory and destroys the input matrix A
-
-    #Directly call the LAPACK function
-    ccall((:zheevr_64_, liblapack), Void,
-                    (Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasChar}, Ptr{BlasInt},
-                     Ptr{Complex128}, Ptr{BlasInt}, Ptr{Float64}, Ptr{Float64},
-                     Ptr{BlasInt}, Ptr{BlasInt}, Ptr{Complex128}, Ptr{BlasInt},
-                     Ptr{Float64}, Ptr{Complex128}, Ptr{BlasInt}, Ptr{BlasInt},
-                     Ptr{Complex128}, Ptr{BlasInt}, Ptr{Float64}, Ptr{BlasInt},
-                     Ptr{BlasInt},Ptr{BlasInt}, Ptr{BlasInt}),
-                    &jobz, &range, &uplo, &n,
-                    A, &n, &vl, &vu,
-                    &il, &iu, &abstol, m,
-                    w, z, &ldz, isuppz,
-                    work, &lwork, rwork, &lrwork,
-                    iwork, &liwork, info)
-
-    #TODO: should we be checking m to make sure there are dim eigenvalues?
-    return scale(z, exp(t*w)) * z'
-
-end
-=#
 
 function unitary_propagator(sys::CompositeQSystem,
                             timeStep::Float64,
@@ -136,9 +21,6 @@ function unitary_propagator(sys::CompositeQSystem,
 
     #Preallocate Hamiltonian memory
     Ham = zeros(Complex128, (dim(sys), dim(sys)))
-
-    #Allocate workspace for the matrix exponential
-    # workspace = allocate_workspace(dim(sys))
 
     times = startTime:timeStep:(endTime-timeStep)
 
@@ -151,7 +33,6 @@ function unitary_propagator(sys::CompositeQSystem,
             #a *= b expands to a = a*b
             hamiltonian_add!(Ham, sys, time)
             expm_eigen(Ham, 1im*2pi*timeStep)
-            # expm_eigen!(Ham, 1im*2pi*timeStep, workspace...)
         end
     else
         Uprop = eye(dim(sys))
@@ -159,14 +40,12 @@ function unitary_propagator(sys::CompositeQSystem,
             #a *= b expands to a = a*b
             hamiltonian_add!(Ham, sys, time)
             Uprop *= expm_eigen(Ham, 1im*2pi*timeStep)
-            # Uprop *= expm_eigen!(Ham, 1im*2pi*timeStep, workspace...)
         end
     end
 
     if (endTime-times[end]) > timeStep
         hamiltonian_add!(Ham, sys, times[end]+timeStep)
         Uprop *= expm_eigen(Ham, 1im*2pi*(endTime-times[end]-timeStep))
-        # Uprop *= expm_eigen!(Ham, 1im*2pi*(endTime-times[end]-timeStep), workspace...)
     end
 
     return Uprop'

--- a/src/read_APS_file.jl
+++ b/src/read_APS_file.jl
@@ -9,10 +9,10 @@ function read_APS_file(filename, startIdx=0)
 	REPEAT_MASK = 2^10 - 1
 	MAX_WAVEFORM_VALUE = 2^13 - 1
 	ADDRESS_UNIT = 4
-	
+
 	chanStrs = ["chan_1", "chan_2", "chan_3", "chan_4"]
 	mrkStrs = ["ch1m1", "ch2m1", "ch3m1", "ch4m1"]
-	AWGData = [chan => Vector{Float64}[] for chan in chanStrs]
+	AWGData = Dict(chan => Vector{Float64}[] for chan in chanStrs)
 
 	h5open(filename, "r") do f
 		for (ct, chanStr) in enumerate(chanStrs)

--- a/src/read_APS_file.jl
+++ b/src/read_APS_file.jl
@@ -12,7 +12,7 @@ function read_APS_file(filename, startIdx=0)
 
 	chanStrs = ["chan_1", "chan_2", "chan_3", "chan_4"]
 	mrkStrs = ["ch1m1", "ch2m1", "ch3m1", "ch4m1"]
-	AWGData = Dict(chan => Vector{Float64}[] for chan in chanStrs)
+	AWGData = [chan => Vector{Float64}[] for chan in chanStrs]
 
 	h5open(filename, "r") do f
 		for (ct, chanStr) in enumerate(chanStrs)

--- a/src/systems.jl
+++ b/src/systems.jl
@@ -8,15 +8,15 @@ export ## Types
        ## Methods
        hamiltonian
 
-#Resonator 
+#Resonator
 type Resonator <: QSystem
     label::AbstractString
     freq::Float64
     dim::Int
-end 
+end
 hamiltonian(r::Resonator) = r.freq*number(r)
 
-#Fixed frequency transmon 
+#Fixed frequency transmon
 type Transmon <: QSystem
     label::AbstractString
     E_C::Float64
@@ -32,7 +32,7 @@ end
 
 hamiltonian(t::Transmon) = sqrt(8*t.E_J*t.E_C)*number(t) - t.E_C/12*(X(t)^4)
 
-#Tunable transmon 
+#Tunable transmon
 
 abstract TunableTransmon <: QSystem
 
@@ -45,7 +45,7 @@ type TunableFullTransmon <: TunableTransmon
     fluxBias::Float64 # flux bias in units of Phi_0
     flux::Float64 #total flux in units of Phi_0
 end
-TunableFullTransmon(label::AbstractString, E_C::Float64, E_J::Float64, d::Float64, dim::Int, fluxBias::Float64) = 
+TunableFullTransmon(label::AbstractString, E_C::Float64, E_J::Float64, d::Float64, dim::Int, fluxBias::Float64) =
   TunableFullTransmon(label, E_C, E_J, d, dim, fluxBias, fluxBias)
 
 #Helper function to calculate effective EJ for a transmon
@@ -56,7 +56,7 @@ function hamiltonian(tt::TunableFullTransmon, t::Float64=0.0)
     return (sqrt(8*tt.E_C*myE_J)*number(tt) - (1.0/12)*tt.E_C*(X(tt)^4))
 end
 
-#Tunable Duffing approx. transmon 
+#Tunable Duffing approx. transmon
 type TunableDuffingTransmon <: TunableTransmon
     label::AbstractString
     E_C::Float64
@@ -67,9 +67,6 @@ type TunableDuffingTransmon <: TunableTransmon
     flux::Float64 #total flux in units of Phi_0
 end
 TunableDuffingTransmon(label::AbstractString, E_C::Float64, E_J::Float64, d::Float64, dim::Int, fluxBias::Float64) = TunableDuffingTransmon(label, E_C, E_J, d, dim, fluxBias, fluxBias)
-
-#Helper function to calculate effective EJ for a transmon
-scale_EJ(flux::Float64, d::Float64) = cos(pi*flux)*sqrt(1 + d^2*(tan(pi*flux)^2))
 
 function hamiltonian(tt::TunableDuffingTransmon, t::Float64=0.0)
     myE_J = tt.E_J*scale_EJ(tt.flux, tt.d)


### PR DESCRIPTION
Fixes a number of issues on Julia 0.5. Doesn't pass tests because of the dependency chain QSimulator.jl -> QuantumInfo.jl -> SchattenNorms.jl -> Convex.jl, and Convex.jl is not currently working in Julia 0.5. But, this should at least improve the current situation.