### PR TITLE
Switch from Grid to Interpolations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: julia
 julia:
-  - 0.4
   - 0.5
+  - 0.6
   - nightly
 matrix:
   allowed_failures:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
-julia 0.4
+julia 0.5
 ExpmV
-Grid
+Interpolations
 HDF5
 Iterators

--- a/src/QSimulator.jl
+++ b/src/QSimulator.jl
@@ -2,7 +2,7 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__()
 
 module QSimulator
 
-using Grid,
+using Interpolations,
       Iterators
 
 import Base: getindex, +


### PR DESCRIPTION
Grid has been deprecated (there is no Julia v0.6 compatible version), so we need
to switch to the newer Interpolations.jl package. Note that this requires
dropping support for Julia 0.4.